### PR TITLE
From json classmethod

### DIFF
--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -1270,7 +1270,7 @@
    ],
    "source": [
     "# construct DataFrame from JSON\n",
-    "df_from_json = rc.from_json(string)\n",
+    "df_from_json = rc.DataFrame.from_json(string)\n",
     "print(df_from_json)"
    ]
   },

--- a/raccoon/__init__.py
+++ b/raccoon/__init__.py
@@ -1,3 +1,3 @@
 
 __version__ = "1.3.2"
-from .dataframe import DataFrame, from_json
+from .dataframe import DataFrame

--- a/raccoon/dataframe.py
+++ b/raccoon/dataframe.py
@@ -1077,21 +1077,21 @@ class DataFrame(object):
         self.index = list(range(self.__len__()))
         self.index_name = 'index'
 
+    # DataFrame creation functions
+    @classmethod
+    def from_json(cls, json_string):
+        """
+        Creates and return a DataFrame from a JSON of the type created by to_json
 
-# DataFrame creation functions
-def from_json(json_string):
-    """
-    Creates and return a DataFrame from a JSON of the type created by to_json
-
-    :param json_string: JSON
-    :return: DataFrame
-    """
-    input_dict = json.loads(json_string)
-    # convert index to tuple if required
-    if input_dict['index'] and isinstance(input_dict['index'][0], list):
-        input_dict['index'] = [tuple(x) for x in input_dict['index']]
-    # convert index_name to tuple if required
-    if isinstance(input_dict['meta_data']['index_name'], list):
-        input_dict['meta_data']['index_name'] = tuple(input_dict['meta_data']['index_name'])
-    data = input_dict['data'] if input_dict['data'] else None
-    return DataFrame(data=data, index=input_dict['index'], **input_dict['meta_data'])
+        :param json_string: JSON
+        :return: DataFrame
+        """
+        input_dict = json.loads(json_string)
+        # convert index to tuple if required
+        if input_dict['index'] and isinstance(input_dict['index'][0], list):
+            input_dict['index'] = [tuple(x) for x in input_dict['index']]
+        # convert index_name to tuple if required
+        if isinstance(input_dict['meta_data']['index_name'], list):
+            input_dict['meta_data']['index_name'] = tuple(input_dict['meta_data']['index_name'])
+        data = input_dict['data'] if input_dict['data'] else None
+        return cls(data=data, index=input_dict['index'], **input_dict['meta_data'])

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -112,24 +112,24 @@ def test_json():
     df = rc.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]}, index=[4, 5, 6], columns=['b', 'a', 'c'])
 
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
     df = rc.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]}, use_blist=True, sorted=False)
 
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
     # empty DataFrame
     df = rc.DataFrame({'a': [], 'b': [], 'c': []})
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
     df = rc.DataFrame()
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
 
@@ -138,7 +138,7 @@ def test_json_objects():
     df = rc.DataFrame({'a': [1, 2], 'b': [4, blist([5, 6])]})
 
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
 
     # the DataFrames are not equal because the blist() was converted to a representation
     with pytest.raises(AssertionError):
@@ -151,14 +151,14 @@ def test_json_multi_index():
     df = rc.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]}, index=[('a', 4), ('b', 5), ('c', 6)])
 
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
     df = rc.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]}, index=[('a', 4), ('b', 5), ('c', 6)],
                       index_name=('first', 'second'))
 
     str = df.to_json()
-    actual = rc.from_json(str)
+    actual = rc.DataFrame.from_json(str)
     assert_frame_equal(df, actual)
 
 


### PR DESCRIPTION
The current `from_json` implementation doesn't allow for loading dataframes as anything other than an rc.DataFrame object.  By making `from_json` a class method anyone subclassing rc.DataFrame to add functionality to it can load dataframes and have the returned object be of the type of their subclass.